### PR TITLE
deb: Removing shlib:depends

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -7,7 +7,7 @@ Build-Depends: debhelper (>=9.0.0)
 
 Package: kano-apps
 Architecture: all
-Depends: ${shlibs:Depends}, ${misc:Depends}, python, python-gi
+Depends: ${misc:Depends}, python, python-gi
 Replaces: kano-desktop (<< 1.0-60)
 Breaks: kano-desktop (<< 1.0-60)
 Conflicts: kano-extras


### PR DESCRIPTION
This causes warnings during package builds. It's intended just for packages with binary files in them.

Related to: https://github.com/KanoComputing/peldins/issues/820

Tested a build on oryx, the warning should be gone.

cc @alex5imon 
