### PR TITLE
Fixing scrollbars disappearing (temporary fix)

### DIFF
--- a/kano_apps/MainWindow.py
+++ b/kano_apps/MainWindow.py
@@ -88,7 +88,10 @@ class MainWindow(ApplicationWindow):
         self._apps = Apps(get_applications(), self)
         self.get_main_area().set_contents(self._apps)
 
-        self._apps.set_current_page(last_page)
+        # FIXME: Momentarily disabling the tab switch
+        # effectively fixes the bug where the scrollbars disappear,
+        # but focus goes back to the first tab pane.
+        #self._apps.set_current_page(last_page)
 
     def _app_loaded(self, widget):
         if self._install is not None:


### PR DESCRIPTION
- Not switching tabs after a pane refresh does not remove the scroll bars
  but the focus moves back to the first tab.
