### PR TITLE
bugfix: Apps not marked installed correctly

### DIFF
--- a/kano_apps/AppData.py
+++ b/kano_apps/AppData.py
@@ -15,6 +15,12 @@ _SYSTEM_ICONS_LOC = '/usr/share/applications/'
 _INSTALLED_PKGS = get_dpkg_dict()[0]
 
 
+def refresh_package_list():
+    global _INSTALLED_PKGS
+
+    _INSTALLED_PKGS = get_dpkg_dict()[0]
+
+
 def try_exec(app):
     path = None
     if len(app) <= 0:

--- a/kano_apps/MainWindow.py
+++ b/kano_apps/MainWindow.py
@@ -13,7 +13,7 @@ from gi.repository import Gtk, Gdk
 from kano_apps import Media
 from kano_apps.UIElements import Contents, get_sudo_password
 from kano_apps.AppGrid import Apps
-from kano_apps.AppData import get_applications
+from kano_apps.AppData import get_applications, refresh_package_list
 from kano_apps.AppManage import install_app, download_app, AppDownloadError, \
     install_link_and_icon
 from kano_apps.AppInstaller import AppInstaller
@@ -105,4 +105,5 @@ class MainWindow(ApplicationWindow):
             pw = inst.get_sudo_pw()
 
         self.set_last_page(0)
+        refresh_package_list()
         self.refresh()


### PR DESCRIPTION
The refresh procedure was checking against an outdated package list that
is being cached for performance reasons. This change reloads the list
after install to make sure it's up to date.

Related to: https://github.com/KanoComputing/peldins/issues/1505

cc @alex5imon 
