### PR TITLE
Migrating the world hook to the new tracker

### DIFF
--- a/kano-world-hook/apps.py
+++ b/kano-world-hook/apps.py
@@ -36,13 +36,8 @@ def launch(app_id):
 
     try:
         try:
-            from kano_profile.apps import load_app_state_variable, save_app_state_variable
-            installed_apps = load_app_state_variable('kano-tracker', 'installed_apps')
-            if not installed_apps:
-                installed_apps = list()
-            installed_apps.append(app_id)
-            installed_apps = list(set(installed_apps))
-            save_app_state_variable('kano-tracker', 'installed_apps', installed_apps)
+            from kano_profile.tracker import track_data
+            track_data("app-installed", app_id)
         except Exception:
             pass
 


### PR DESCRIPTION
Doesn't have a dependency on profile, because the modified code is a plugin into kano profile - kano profile has to deal with that. 

Related to:
https://github.com/KanoComputing/peldins/issues/1358
https://github.com/KanoComputing/kano-profile/pull/201

cc @alex5imon 