### PR TITLE
Removing pcmanfm settings mode app.

### DIFF
--- a/kano_apps/AppData.py
+++ b/kano_apps/AppData.py
@@ -86,7 +86,7 @@ def get_applications(parse_cmds=True):
         "make-snake.desktop", "kano-video.desktop", "lxsession-edit.desktop",
         "lxrandr.desktop", "lxinput.desktop", "obconf.desktop",
         "openbox.desktop", "libfm-pref-apps.desktop", "lxappearance.desktop",
-        "htop.desktop"
+        "htop.desktop", "pcmanfm-desktop-pref.desktop"
     ]
     apps = []
     if os.path.exists(loc):


### PR DESCRIPTION
 * pcmanfm --desktop-pref fails complaining about the desktop manager,
   and we actually do not need users to change settings via this tool.
   adding it to the blacklist.

cc @Ealdwulf @pazdera 