### PR TITLE
Conditionally add icons to the desktop when reinstalling

### DIFF
--- a/kano_apps/AppGrid.py
+++ b/kano_apps/AppGrid.py
@@ -614,4 +614,6 @@ class AppGridEntry(Gtk.EventBox):
         self._app['origin'] = new_app['origin']
         remove_from_desktop(self._app)
         self._apps.update_app(new_app)
-        add_to_desktop(new_app)
+
+        if new_app.get('desktop'):
+            add_to_desktop(new_app)


### PR DESCRIPTION
This should fix the problem where an icon that shouldn't be on the desktop was added when reinstalling an app.

cc @tombettany @convolu @alex5imon 